### PR TITLE
Vue.use support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,35 @@
 Debounce directive for Vue2 to debounce input typing. Forked originally from https://github.com/vuejs-tips/v-debounce
 Updated to include support for IE.
 
+## Install
+Install the NPM package:
+```
+yarn add v-debounce
+
+# or if you prefer to use npm
+
+npm install --save v-debounce
+```
+
+And then register the directive in your Vue inscance. You might do that globally using `Vue.use` or by importing the directive directly in your component.
+
+```js
+/* --- Install the directive globally --- */
+import Vue from 'Vue'
+import debounce from 'v-debounce'
+
+Vue.use(debounce)
+
+/* --- Import the directive directly in the component --- */
+// In single file component
+
+import { directive } from 'v-debounce'
+
+export default {
+  directives: { debounce: directive }
+}
+```
+
 ## Usage
 
 **Template:**
@@ -17,8 +46,14 @@ In your script section, customize delay and keep track of when term changes, whi
 
 **Script:**
 
-```
+```html
+<template>
+  <input v-model.lazy="term" v-debounce="delay" placeholder="Search for something" />
+</template>
+
 <script>
+import { directive } from 'v-debounce'
+
 export default {
   name: 'example',
   data () {
@@ -34,7 +69,7 @@ export default {
     }
   },
   directives: {
-    debounce
+    debounce: directive
   }
 }
 </script>

--- a/debounce.js
+++ b/debounce.js
@@ -1,9 +1,10 @@
-module.exports = function debounce (fn, delay) {
-  var timeoutID = null
+module.exports = function (fn, delay) {
+  let timeoutID = null
+
   return function () {
     clearTimeout(timeoutID)
-    var args = arguments
-    var that = this
+    const args = arguments
+    const that = this
     timeoutID = setTimeout(function () {
       fn.apply(that, args)
     }, delay)

--- a/index.js
+++ b/index.js
@@ -22,4 +22,7 @@ function createNewEvent(eventName) {
   return e
 }
 
-module.exports = directive
+module.exports = {
+  install: (Vue) => { Vue.directive('debounce', directive) },
+  directive
+}


### PR DESCRIPTION
This PR adds Vue.use support. This is achieved by exporting an `install` function in the main `index.js` file.

This PR **might break retrocompatibility,** as to use it in a Single File Component you have to import the directive like this:
```js
import { directive } from 'v-debounce'
// or
import { directive as debounce } from 'v-debounce'
// or using Common.js
const debounce = require('v-debounce').directive
```

I updated the readmy accordingly to my modifications.

I also took the liberty to change few `var` in `let` and `const`.